### PR TITLE
Pass action and not function as param in send-sender-action

### DIFF
--- a/src/fb_messenger/send.clj
+++ b/src/fb_messenger/send.clj
@@ -37,7 +37,7 @@
   "send Sender Action to PSID via FB Send Api, see:
    https://developers.facebook.com/docs/messenger-platform/send-api-reference/sender-actions"
   ([psid sender-action]
-   (send-sender-action psid send-sender-action *page-access-token*))
+   (send-sender-action psid sender-action *page-access-token*))
   ([psid sender-action page-access-token]
    (post-api "me/messages"
              {:recipient     {:id psid}


### PR DESCRIPTION
Tried to use this function in https://github.com/lemmings-io/02-facebook-example/compare/delay-and-typing#diff-1324baef0e4d9e41b0396348051b817fR113 but was always getting this error: 


![stacktrace](https://user-images.githubusercontent.com/1609297/27890046-bacddd18-61f0-11e7-8153-7e92e5b3e6a4.png)


Looks like it is passing the function itself and not the string for the action.
I am fairly positive the intention is to pass the action string, so this change should make it work although I haven't tried it myself.